### PR TITLE
Handle error string throw from taichi runtime on android

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -7,25 +7,32 @@ const uint32_t HEIGHT = 16;
 int main(int argc, const char** argv) {
   ti::Runtime runtime(TI_ARCH_VULKAN);
 
-  ti::AotModule aot_module = runtime.load_aot_module("module");
-  ti::ComputeGraph g_run = aot_module.get_compute_graph("g_run");
+  try {
+    ti::AotModule aot_module = runtime.load_aot_module("module");
+    ti::ComputeGraph g_run = aot_module.get_compute_graph("g_run");
 
-  ti::NdArray<float> arr =
-    runtime.allocate_ndarray<float>({ WIDTH, HEIGHT }, {}, true);
+    ti::NdArray<float> arr =
+      runtime.allocate_ndarray<float>({ WIDTH, HEIGHT }, {}, true);
 
-  g_run["arr"] = arr;
-  g_run.launch();
-  runtime.wait();
+    g_run["arr"] = arr;
+    g_run.launch();
+    runtime.wait();
 
-  auto arr_data = (const float*)arr.map();
-  for (uint32_t y = 0; y < HEIGHT; ++y) {
-    for (uint32_t x = 0; x < WIDTH; ++x) {
-      float value = arr_data[y * WIDTH + x];
-      std::cout << (value > 0.5f ? '#' : ' ');
+    auto arr_data = (const float*)arr.map();
+    for (uint32_t y = 0; y < HEIGHT; ++y) {
+      for (uint32_t x = 0; x < WIDTH; ++x) {
+        float value = arr_data[y * WIDTH + x];
+        std::cout << (value > 0.5f ? '#' : ' ');
+      }
+      std::cout << std::endl;
     }
-    std::cout << std::endl;
+    arr.unmap();
+  } catch (std::string& err) {
+      std::cout << err << std::endl;
+  } catch (...) {
+      std::cout << "Unknown error" << std::endl;
+
   }
-  arr.unmap();
 
   return 0;
 }


### PR DESCRIPTION
In my case when the program fails to launch due to generated spirv version/extension cannot met it throws
```
[vulkan_api.cpp:create_compute_pipeline@333] Vulkan Error : 5 : failed
to create compute pipeline
```

Let's catch this and and properly show it, better than the previous crash:
```
terminating with uncaught exception of type
std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>,
std::__ndk1::allocator<char> >
```